### PR TITLE
Update README and --help

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,11 +161,11 @@ The next step is the activation/deactivation of facultative components and their
 Facultative components, deactivated by default, are: Annotation, Loop-Razor, Mouse, NERVirulent and Conservation.
 
 </p>
-See next section for setting examples.
+See last section for setting examples.
 
 
 ### Showing output and results
-This an output example, showing the percentage of analysis completion:
+This is an output example, showing the percentage of analysis completion:
 ```
  ./NERVE.sh -p1 test.fasta -g n
 wrote config file /root/.config/epitopepredict/default.conf
@@ -185,7 +185,7 @@ End NERVE computation successfully.
 
 The default working directory, where all result files produced during NERVE analysis are saved, is the NERVE folder.
 
-To change it, use ``-wd,--working_dir``` as showed:
+To change it, use ```-wd,--working_dir``` as showed:
 
 ```
 ./NERVE.sh -p1 UP000000594 -g p -wd ./chosen_path
@@ -207,11 +207,11 @@ To change it, use ``-wd,--working_dir``` as showed:
 ```
 ./NERVE.sh -p1 test.fasta -g n -m True -rz True -rl 75
 ```
-3) Here, two facoltative components are activated (Mouse immunity and Loop-razor).Then, minimum length of  considered loop, with Loop-razor, is set to 75aa (from 50aa).
+3) Here, two facultative components are activated (Mouse immunity and Loop-razor).Then, minimum length of  considered loop, with Loop-razor, is set to 75aa (from 50aa).
 
 ```
 ./NERVE.sh -p1 test.fasta -g n -p2 test2.fasta
 ```
 4) In this case, adding test2.fasta, the component Conservation is automatically activated, allowing the user to infer antigen conservation.
 
-For more info about components working visit the FAQ section of https://nerve-bio.org
+**For more info about components working visit the FAQ section of https://nerve-bio.org**

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ Definitions and setting options are shown in detail for each of them here above,
 
 All the other showed arguments are optional. So, if they're not set by the user, their related default value is used during NERVE computation.
 
-### Starting the analysis:
+### Starting the analysis
 
 To start with NERVE, the ```-p1,--proteome1``` file, which contains all bacterial FASTA proteins to be analyzed, has to be put in the NERVE folder.
  

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@
 * **Community-Driven Development:** the open-source model encourages community participation, ensuring that NERVE remains aligned with the evolving needs of the vaccine research community. 
 
 
-Whether it's reporting bugs, suggesting improvements, or developing new features, your input is valuable
+Whether it's reporting bugs, suggesting improvements, or developing new features, your input is valuable.
 
 We welcome contributions from researchers interested in shaping the future of NERVE! 
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-iose # NERVE
+# NERVE
 
 <div align="center"
   
@@ -59,7 +59,7 @@ NERVE can be used as a stand alone version taking advantage of [Docker](https://
 ```
 git clone https://github.com/nerve-bio/NERVE.git
 ```
-4) Navigate to the correct folder:
+4) Navigate to the correct folder (your default working directory):
 ```
 cd NERVE
 ```
@@ -131,10 +131,32 @@ Definitions and setting options are shown in detail for each of them here above,
 * ```-p1  ```,```--proteome1  ``` 
 * ```-g ```,  ```--gram ``` 
 
-All the other arguments showed are optional. So, if they're not set by the user, their related default value is used during NERVE computation.
+All the other showed arguments are optional. So, if they're not set by the user, their related default value is used during NERVE computation.
 
 
-**directory and how to use it**
+To start with NERVE, the ```-p1,--proteome1``` file, which contains all bacterial FASTA proteins to be analyzed, has to be put in the NERVE folder.
+ 
+
+```
+./NERVE.sh -p1 anthracis.fasta -g p
+```
+Here, the example file "anthracis.fasta", with Gram positive proteins, needs to be saved in the NERVE folder.
+
+But the user can also retrieve it from Uniprot, writing the correct ID of the chosen proteome:
+
+```
+./NERVE.sh -p1 UP000000594 -g p
+
+```
+Here, the reported Uniprot proteome ID is the *Bacillus anthracis* (strain Ames Ancestor) one.
+
+
+The default working directory, where all result files produced during NERVE analysis are saved, is always the NERVE folder.
+
+To change it, the user has to specify the path to the new chosen folder using the command ```-wd,--working_dir```
+
+```
+./NERVE.sh -p1 UP000000594 -g p -wd ```
 
 
 **Here is a list of different examples to show how to correctly set NERVE arguments:**
@@ -153,5 +175,5 @@ All the other arguments showed are optional. So, if they're not set by the user,
 ./NERVE.sh -p1 test.fasta -g n -p2 test2.fasta
 ```
 3) In this case, adding test2.fasta, the component Conservation is automatically activated, allowing the user to infer antigen conservation. 
-For more info about components working visit the FAQ section of https://nerve-bio.org
 
+For more info about components working visit the FAQ section of https://nerve-bio.org

--- a/README.md
+++ b/README.md
@@ -66,7 +66,6 @@ cd NERVE
 4) Run NERVE (the first time it will take a few minutes)
 ```
 ./NERVE.sh --help
-
 ```
 
 This is the expected output:

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@
 
 **Benefits for Vaccine Research:**
 
-* **Accessibility:**: Researchers worldwide can access and utilize NERVE without barriers, accelerating vaccine development efforts globally. 
+* **Accessibility:** Researchers worldwide can access and utilize NERVE without barriers, accelerating vaccine development efforts globally. 
 * **Transparency:** Allowing researchers to scrutinize the code, identify potential issues, and contribute to its refinement. 
 * **Collaboration:** By enabling researchers to share, modify, and extend the pipeline, leading to innovative advancements. 
 * **Community-Driven Development:** The open-source model encourages community participation, ensuring that NERVE remains aligned with the evolving needs of the vaccine research community. 

--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ To change it, the user has to specify the path to the new chosen folder using th
 ```
 ./NERVE.sh -p1 test.fasta -g n -m True -rz True -rl 75
 ```
-3) Here, two facoltative components are activated (Mouse immunity and Loop-razor).Then, minimum length of  considered loop, with Loop-razor, is set to 75aa instead of 50aa.
+3) Here, two facoltative components are activated (Mouse immunity and Loop-razor).Then, minimum length of  considered loop, with Loop-razor, is set to 75aa (from 50aa).
 
 ```
 ./NERVE.sh -p1 test.fasta -g n -p2 test2.fasta

--- a/README.md
+++ b/README.md
@@ -1,9 +1,16 @@
 # NERVE
 
-Software for Reverse Vaccinology. For web-tool please visit: https://nerve-bio.org
+NERVE (New Enhanced Reverse Vaccinology Environment) is an open-source, reverse vaccinology environment, with which you can analyze bacterial proteomes to get the best protein vaccine candidates (PVCs).
+<p>
+The project was initially developed in Perl in 2006. You can find all the related information on the article at: https://www.ncbi.nlm.nih.gov/pmc/articles/PMC1570458
+</p>
+<p>
+Now we are carrying on this project independently from the original developer and this is the Github page of the stand-alone version of NERVE 2.0. Web-server app, instead, is available at:
+https://nerve-bio.org
+</p>
 
-### Stand-alone usage:
-NERVE can be used as a stand alone verison taking advantage of [Docker](https://www.docker.com/) in linux systems.
+### Installation procedure of stand-alone version:
+NERVE can be used as a stand alone verison taking advantage of [Docker](https://www.docker.com/) in Linux systems.
 
 1) install Docker following [these instructions](https://docs.docker.com/engine/install/) and [the post-installation procedure](https://docs.docker.com/engine/install/linux-postinstall/)
 2) clone the repository:
@@ -17,16 +24,18 @@ cd NERVE
 4) Run NERVE (the first time it will take a few minutes)
 ```
 ./NERVE.sh --help
+
 ```
+With help, you can visualize all arguments (parameters and modules of NERVE).
 Expected output:
 ```
 usage: NERVE.py [-h] [-a] [-ev] -g [-ml] [-mm] [-m] [-mpsl] -p1 [-p2] [-paefilter] [-pacfilter] [-pl] [-rz] [-rl] [-s] [-ss] [-tdl] [-vl] [-vir]
                 [-ep] [-m1l] [-m2l] [-m1ovr] [-m2ovr] [-prt] [-wd] [-nd] [-id] [-dfd] [-epp]
 
-Run vaccine candidate prediction
+Run vaccine candidate prediction:
 
 optional arguments:
-  -h, --help            show this help message and exit
+  -h, --help        show this help message and exit
   -a, --annotation  Activation (True) or deactivation (False) of annotation module. Uses DeepFri to retrieve protein functional onthologies (default: True)
   -ev, --e_value    Expect-value used in blastp for immunity modules (default: 1e-10)
   -g, --gram        Negative (n) or positive (p) gram stain of the pathogen of interest (default: None)
@@ -39,13 +48,7 @@ optional arguments:
                         of the i-protein' <= mouse_peptides_sum_limit and with absence of match mhc-I and Mhc-II mouse ligands are selected (default: 0.15)
   -p1, --proteome1  Path to proteome or Uniprot proteome ID (see: https://www.uniprot.org/proteomes/?query=&sort=score) (default: None)
   -p2, --proteome2  Path to proteome or Uniprot proteome ID (see: https://www.uniprot.org/proteomes/?query=&sort=score) (default: None)
-  -paefilter, --p_ad_extracellular_filter 
-                        Parameter of select module. Extracellular proteins with a probability of adhesin (pad) lower than p_ad_extracellular_filter are discarded (0.-1) (default:
-                        0.38)
-  -pacfilter, --p_ad_no_citoplasm_filter 
-                        Parameter of select module. Non-cytoplasmic Proteins with a probability of adhesin (pad) lower than p_ad_no_citoplasm_filter are discarded (0.-1) (default:
-                        0.46)
-  -pl, --padlimit   Set the probability of adhesin (pad) value cut-off for proteins with 'Unknown' localization in the select module. Thus, these proteins with a pad value < cut-
+  -pl, --padlimit   Set the probability of adhesin (pad) value cut-off for all proteins in select module. Thus, these proteins with a pad value < cut-
                         off are discarded (0.-1) (default: 0.5)
   -rz, --razor      Activation (True) or deactivation (False) of the loop-razor module. This module allows the recovery of protein vaccine candidates, with more than 2
                         transmembrane domains, that would otherwise be discarded in the select module. The longest loop with minimum len == 'razlen' aa will replace the original

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 
  * **Machine Learning and Alignment Analysis**, using  ML methods for antigen analysis
  * **Flexible Usage**, customizing your settings
- * **Stand-alone Docker Version**, working across Windows, macOS, and Linux.
+ * **Stand-alone Docker Version**, reducing dependencies for its installation
  * **Intuitive Web-based GUI**,
  * **Complete Python Rewrite**, enhancing its performance and maintainability.
  * **Ongoing Development**, continuously evolving with new features and improvements.
@@ -46,7 +46,7 @@ We welcome contributions from researchers interested in shaping the future of NE
 
 
 ## Installation procedure of stand-alone version:
-NERVE can be used as a stand alone verison taking advantage of [Docker](https://www.docker.com/) in Linux systems.
+NERVE can be used as a stand alone version taking advantage of [Docker](https://www.docker.com/) in Linux systems.
 
 1) Install Docker following [these instructions](https://docs.docker.com/engine/install/) and [the post-installation procedure](https://docs.docker.com/engine/install/linux-postinstall/)
 2) Clone the repository:
@@ -119,25 +119,25 @@ NERVE arguments:
 ## Common usage and tips:
 
 With help, you can visualize all possible arguments, which include all user-settable parameters and activation or deactivation of NERVE components.
-Definitions and setting options are shown in detail for each of them.
+Definitions and setting options are shown in detail for each of them here above, in the ```help``` output.
 
 **Mandatory arguments:** 
 * ```-p1  ```,```--proteome1  ``` 
 * ```-g ```,  ```--gram ``` 
 
-All the other arguments, showed in the help section are optional. So, if they're set by the user, their related default value is used during NERVE computation.
+All the other arguments showed are optional. So, if they're not set by the user, their related default value is used during NERVE computation.
 
 **Here is a list of different examples to show how to correctly set NERVE arguments:**
 
 ```
 ./NERVE.sh -p1 test.fasta -g n
 ```
-1) This is a run example with the minimum number of arguments (the two mandatory ones). Here we're considering a file with Gram negative proteins.
+1) This is a run example with the minimum number of arguments (the two mandatory ones). Here we're considering a FASTA file (test.fasta) with Gram negative proteins.
 
 ```
 ./NERVE.sh -p1 test.fasta -g n -s False -vir True -vl 0.8
 ```
-2) The same file with gram negative proteins will be analyzed activating NERVirulent and setting its cut-off to 0.8 (instead of default " 0.5 "). Without activating Select (```-s False```), PVCs are not filtered so in the results file there will be the list of all proteins with their related analyzed info.
+2) The same file with Gram negative proteins will be analyzed activating NERVirulent and setting its cut-off to 0.8 (instead of default " 0.5 "). Without activating Select (```-s False```), PVCs are not filtered. So, in the results file, there will be the list of all proteins with their related analyzed info.
 
 ```
 ./NERVE.sh -p1 test.fasta -g n -p2 test2.fasta

--- a/README.md
+++ b/README.md
@@ -29,10 +29,8 @@ cd NERVE
 With help, you can visualize all arguments (parameters and modules of NERVE).
 Expected output:
 ```
-usage: NERVE.py [-h] [-a] [-ev] -g [-ml] [-mm] [-m] [-mpsl] -p1 [-p2] [-paefilter] [-pacfilter] [-pl] [-rz] [-rl] [-s] [-ss] [-tdl] [-vl] [-vir]
+usage: NERVE.py [-h] [-a] [-ev] -g [-ml] [-mm] [-m] [-mpsl] -p1 [-p2] [-pl] [-rz] [-rl] [-s] [-ss] [-tdl] [-vl] [-vir]
                 [-ep] [-m1l] [-m2l] [-m1ovr] [-m2ovr] [-prt] [-wd] [-nd] [-id] [-dfd] [-epp]
-
-Run vaccine candidate prediction:
 
 optional arguments:
   -h, --help        show this help message and exit
@@ -81,4 +79,6 @@ optional arguments:
                         Path to DeepFri folder (download from: https://github.com/flatironinstitute/DeepFRI) (default: /usr/nerve_python/assets/DeepFri)
   -epp, --ep_plots  Epitopes plotting script (default: True)
   ```
+
+### Common usage:
 

--- a/README.md
+++ b/README.md
@@ -34,9 +34,9 @@ se # NERVE
  * **Complete Python Rewrite**, enhancing its performance and maintainability.
  * **Ongoing Development**, continuously evolving with new features and improvements.
  * **Comprehensive Output**, including:
-    * A CSV file summarizing all candidate proteins with scores and predicted characteristics (P_adhesin, P_antigen, location, etc.).
-    * A separate CSV file listing discarded proteins.
-    * Dedicated folders containing additional files (CSVs and PNGs) for each selected protein with predicted linear epitopes. 
+    * a CSV file summarizing all candidate proteins with scores and predicted characteristics (P_adhesin, P_antigen, location, etc.).
+    * a separate CSV file listing discarded proteins.
+    * dedicated folders containing additional files (CSVs and PNGs) for each selected protein with predicted linear epitopes. 
 
 **Benefits for Vaccine Research:**
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,10 @@
   </p>
   <p>
   Users can also leverage a user-friendly web-based 
-  graphical interface (GUI) hosted on our dedicated server: https://nerve-bio.org.  This GUI empowers even novice users to operate NERVE with ease, requiring only the proteome FASTA file as input. It further enhances the experience by allowing visualization of analysis results using our 
+  graphical interface (GUI) hosted on our dedicated server: https://nerve-bio.org.  This GUI empowers even novice users to operate NERVE with ease, requiring only the proteome FASTA file as input.
+</p>
+<p>
+ It further enhances the experience by allowing visualization of analysis results using our 
   custom-built visualizer. Additionally, this tool facilitates the identification of epitopes (and their constituent parts) predicted to bind to multiple HLA alleles.
   </p>
 </div>

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ All the other arguments showed are optional. So, if they're not set by the user,
 ```
 ./NERVE.sh -p1 test.fasta -g n
 ```
-1) This is a run example with the minimum number of arguments (the two mandatory ones). Here we're considering a FASTA file (test.fasta) with Gram negative proteins.
+1) This is a run example with the minimum number of arguments (the two mandatory ones). Here we're considering a FASTA file (test.fasta) with Gram negative proteins (```-g n```).
 
 ```
 ./NERVE.sh -p1 test.fasta -g n -s False -vir True -vl 0.8

--- a/README.md
+++ b/README.md
@@ -154,9 +154,13 @@ But the user can also retrieve a specific proteome from Uniprot, writing its cor
 ```
 Here, the reported Uniprot proteome ID is the one of *Bacillus anthracis* (strain Ames Ancestor).
 
-The next step is the activation/deactivation of facultative components and their parameters settings.
-Facultative components, deactivated by default, are: Annotation, Loop-Razor, Mouse, NERVirulent and Conservation.
-See next section to see some setting examples.
+**The next step is the activation/deactivation of facultative components and their parameters settings.**
+<p>
+  
+**Facultative components, deactivated by default, are: Annotation, Loop-Razor, Mouse, NERVirulent and Conservation**.
+
+</p>
+See next section for setting examples.
 
 
 ### Showing output and results

--- a/README.md
+++ b/README.md
@@ -133,6 +133,10 @@ Definitions and setting options are shown in detail for each of them here above,
 
 All the other arguments showed are optional. So, if they're not set by the user, their related default value is used during NERVE computation.
 
+
+**directory and now to use it**
+
+
 **Here is a list of different examples to show how to correctly set NERVE arguments:**
 
 ```

--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ Definitions and setting options are shown in detail for each of them here above,
 
 All the other showed arguments are optional. So, if they're not set by the user, their related default value is used during NERVE computation.
 
+###Starting the analysis:
 
 To start with NERVE, the ```-p1,--proteome1``` file, which contains all bacterial FASTA proteins to be analyzed, has to be put in the NERVE folder.
  
@@ -149,6 +150,8 @@ But the user can also retrieve it from Uniprot, writing the correct ID of the ch
 Here, the reported Uniprot proteome ID is the *Bacillus anthracis* (strain Ames Ancestor) one.
 
 
+###Showing output and results
+
 The default working directory, where all result files produced during NERVE analysis are saved, is always the NERVE folder.
 
 To change it, the user has to specify the path to the new chosen folder using the command ```-wd,--working_dir```
@@ -156,8 +159,9 @@ To change it, the user has to specify the path to the new chosen folder using th
 ```
 ./NERVE.sh -p1 UP000000594 -g p -wd 
 ```
+###Run examples
 
-**Here is a list of different examples to show how to correctly set NERVE arguments:**
+**Here are some different examples to show how to correctly set NERVE arguments:**
 
 ```
 ./NERVE.sh -p1 test.fasta -g n
@@ -172,6 +176,6 @@ To change it, the user has to specify the path to the new chosen folder using th
 ```
 ./NERVE.sh -p1 test.fasta -g n -p2 test2.fasta
 ```
-3) In this case, adding test2.fasta, the component Conservation is automatically activated, allowing the user to infer antigen conservation. 
+3) In this case, adding test2.fasta, the component Conservation is automatically activated, allowing the user to infer antigen conservation.
 
 For more info about components working visit the FAQ section of https://nerve-bio.org

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
   
   NERVE (New Enhanced Reverse Vaccinology Environment) is an open-source, reverse vaccinology environment, with which you can analyze bacterial proteomes in FASTA format to get the best protein vaccine candidates (PVCs) and their epitopes. 
   <p>
-  The project was initially developed in Perl in 2006. You can find all the related information on the article at: https://www.ncbi.nlm.nih.gov/pmc/articles/PMC1570458
+  The project was initially developed in Perl, in 2006, for Linux users only. You can find all the related information on the article at: https://www.ncbi.nlm.nih.gov/pmc/articles/PMC1570458
   </p>
   <p>
   Now, we are carrying on this project independently from the original developer and this is the Github page of the NERVE 2.0-stand-alone version. 

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ NERVE arguments:
 ## Common usage and tips:
 
 With help, you can visualize all possible arguments, which include all user-settable parameters and activation or deactivation of NERVE components.
-Definitions and setting options are shown in detail for each of them here above, in the ```help``` output.
+Definitions and setting options are shown in detail for each of them here above.
 
 **Mandatory arguments:** 
 * ```-p1  ```,```--proteome1  ``` 
@@ -140,7 +140,7 @@ To start with NERVE, the ```-p1,--proteome1``` file, which contains all bacteria
 ```
 ./NERVE.sh -p1 anthracis.fasta -g p
 ```
-Here, the example file "anthracis.fasta", with Gram positive proteins, is saved the NERVE folder.
+Here, the example file "anthracis.fasta", with Gram positive proteins, is saved in the NERVE folder.
 
 But the user can also retrieve a specific proteome from Uniprot, writing its correct ID:
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 </p>
 <p>
  It further enhances the experience by allowing visualization of analysis results using our 
-  custom-built visualizer,also facilitating the identification of epitopes (and their constituent parts) predicted to bind to multiple HLA alleles.
+  custom-built visualizer, also facilitating the identification of epitopes (and their constituent parts) predicted to bind to multiple HLA alleles.
   </p>
 </div>
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@
 
 **Benefits for Vaccine Research:**
 
-* **Accessibility:** Researchers worldwide can access and utilize NERVE without barriers, accelerating vaccine development efforts globally. 
+* **Accessibility:** Researchers worldwide can access and use NERVE without barriers, accelerating vaccine development efforts globally. 
 * **Transparency:** Allowing researchers to scrutinize the code, identify potential issues, and contribute to its refinement. 
 * **Collaboration:** By enabling researchers to share, modify, and extend the pipeline, leading to innovative advancements. 
 * **Community-Driven Development:** The open-source model encourages community participation, ensuring that NERVE remains aligned with the evolving needs of the vaccine research community. 

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ Only the last two ones are acttivated by default.
 See last section for setting examples.
 
 
-### Showing output and results
+### Showing computation
 This is an output example, showing the percentage of analysis completion:
 ```
  ./NERVE.sh -p1 test.fasta -g n

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
- # NERVE
+se # NERVE
 
 <div align="center"
   
@@ -134,7 +134,7 @@ Definitions and setting options are shown in detail for each of them here above,
 All the other arguments showed are optional. So, if they're not set by the user, their related default value is used during NERVE computation.
 
 
-**directory and now to use it**
+**directory and how to use it**
 
 
 **Here is a list of different examples to show how to correctly set NERVE arguments:**

--- a/README.md
+++ b/README.md
@@ -40,10 +40,10 @@
 
 **Benefits for Vaccine Research:**
 
-* **Accessibility:** Researchers worldwide can access and use NERVE without barriers, accelerating vaccine development efforts globally. 
-* **Transparency:** Allowing researchers to scrutinize the code, identify potential issues, and contribute to its refinement. 
-* **Collaboration:** By enabling researchers to share, modify, and extend the pipeline, leading to innovative advancements. 
-* **Community-Driven Development:** The open-source model encourages community participation, ensuring that NERVE remains aligned with the evolving needs of the vaccine research community. 
+* **Accessibility:** researchers worldwide can access and use NERVE without barriers, accelerating vaccine development efforts globally. 
+* **Transparency:** allowing researchers to scrutinize the code, identify potential issues, and contribute to its refinement. 
+* **Collaboration:** by enabling researchers to share, modify, and extend the pipeline, leading to innovative advancements. 
+* **Community-Driven Development:** the open-source model encourages community participation, ensuring that NERVE remains aligned with the evolving needs of the vaccine research community. 
 
 
 Whether it's reporting bugs, suggesting improvements, or developing new features, your input is valuable.

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ We welcome contributions from researchers interested in shaping the future of NE
 NERVE can be used as a stand alone version taking advantage of [Docker](https://www.docker.com/) in Linux systems.
 
 **1) Install Docker following [these instructions](https://docs.docker.com/engine/install/) and [the post-installation procedure](https://docs.docker.com/engine/install/linux-postinstall/):**
+
 **2) Clone the repository:**
 ```
 git clone https://github.com/nerve-bio/NERVE.git

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ Definitions and setting options are shown in detail for each of them here above,
 
 All the other showed arguments are optional. So, if they're not set by the user, their related default value is used during NERVE computation.
 
-###Starting the analysis:
+### Starting the analysis:
 
 To start with NERVE, the ```-p1,--proteome1``` file, which contains all bacterial FASTA proteins to be analyzed, has to be put in the NERVE folder.
  
@@ -150,7 +150,7 @@ But the user can also retrieve it from Uniprot, writing the correct ID of the ch
 Here, the reported Uniprot proteome ID is the *Bacillus anthracis* (strain Ames Ancestor) one.
 
 
-###Showing output and results
+### Showing output and results
 
 The default working directory, where all result files produced during NERVE analysis are saved, is always the NERVE folder.
 
@@ -159,7 +159,7 @@ To change it, the user has to specify the path to the new chosen folder using th
 ```
 ./NERVE.sh -p1 UP000000594 -g p -wd 
 ```
-###Run examples
+### Run examples
 
 **Here are some different examples to show how to correctly set NERVE arguments:**
 

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ NERVE arguments:
 
 ## Common usage and tips:
 
-With help, you can visualize all possible arguments, which include all user-settable parameters and activation or deactivation of NERVE components.
+With help, you can visualize all possible arguments, which include all user-settable parameters and activation or deactivation of some NERVE components.
 Definitions and setting options are shown in detail for each of them here above.
 
 **Mandatory arguments:** 
@@ -136,28 +136,32 @@ All the other showed arguments are optional. So, if they're not set by the user,
 
 To start with NERVE, the ```-p1,--proteome1``` file, which contains all bacterial FASTA proteins to be analyzed, has to be put in the NERVE folder.
  
-
 ```
 ./NERVE.sh -p1 anthracis.fasta -g p
 ```
 Here, the example file "anthracis.fasta", with Gram positive proteins, is saved in the NERVE folder.
+
 
 But the user can also retrieve a specific proteome from Uniprot, writing its correct ID:
 
 ```
 ./NERVE.sh -p1 UP000000594 -g p
 ```
-Here, the reported Uniprot proteome ID is the *Bacillus anthracis* (strain Ames Ancestor) one.
+Here, the reported Uniprot proteome ID is the one of *Bacillus anthracis* (strain Ames Ancestor).
+
+The next step is the activation/deactivation of facultative components and their parameters settings.
+Facultative components, deactivated by default, are: Annotation, Loop-Razor, Mouse, NERVirulent and Conservation 
 
 
 ### Showing output and results
+This an output example, showing the percentage of 
 
 The default working directory, where all result files produced during NERVE analysis are saved, is always the NERVE folder.
 
-To change it, the user has to specify the path to the new chosen folder using the command ```-wd,--working_dir```
+To change it, use ``-wd,--working_dir``` as showed:
 
 ```
-./NERVE.sh -p1 UP000000594 -g p -wd 
+./NERVE.sh -p1 UP000000594 -g p -wd ./chosen_path
 ```
 ### Run examples
 

--- a/README.md
+++ b/README.md
@@ -145,7 +145,6 @@ But the user can also retrieve it from Uniprot, writing the correct ID of the ch
 
 ```
 ./NERVE.sh -p1 UP000000594 -g p
-
 ```
 Here, the reported Uniprot proteome ID is the *Bacillus anthracis* (strain Ames Ancestor) one.
 
@@ -155,8 +154,8 @@ The default working directory, where all result files produced during NERVE anal
 To change it, the user has to specify the path to the new chosen folder using the command ```-wd,--working_dir```
 
 ```
-./NERVE.sh -p1 UP000000594 -g p -wd ```
-
+./NERVE.sh -p1 UP000000594 -g p -wd 
+```
 
 **Here is a list of different examples to show how to correctly set NERVE arguments:**
 

--- a/README.md
+++ b/README.md
@@ -13,11 +13,11 @@
   The project was initially developed in Perl in 2006. You can find all the related information on the article at: https://www.ncbi.nlm.nih.gov/pmc/articles/PMC1570458
   </p>
   <p>
-  Now, we are carrying on this project independently from the original developer and this is the Github page of the NERVE 2.0-stand-alone version. Users can also leverage a user-friendly web-based 
-  graphical interface (GUI) hosted on our dedicated server: https://nerve-bio.org.
+  Now, we are carrying on this project independently from the original developer and this is the Github page of the NERVE 2.0-stand-alone version. 
   </p>
   <p>
-  This GUI empowers even novice users to operate NERVE with ease, requiring only the proteome FASTA file as input. It further enhances the experience by allowing visualization of analysis results using our 
+  Users can also leverage a user-friendly web-based 
+  graphical interface (GUI) hosted on our dedicated server: https://nerve-bio.org.  This GUI empowers even novice users to operate NERVE with ease, requiring only the proteome FASTA file as input. It further enhances the experience by allowing visualization of analysis results using our 
   custom-built visualizer. Additionally, this tool facilitates the identification of epitopes (and their constituent parts) predicted to bind to multiple HLA alleles.
   </p>
 </div>

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ se # NERVE
   
   NERVE (New Enhanced Reverse Vaccinology Environment) is an open-source, reverse vaccinology environment, with which you can analyze bacterial proteomes in FASTA format to get the best protein vaccine candidates (PVCs) and their epitopes. 
   <p>
-  The project was initially developed in Perl, in 2006, for Linux-users only. You can find all the related info on the article at: https://www.ncbi.nlm.nih.gov/pmc/articles/PMC1570458
+  The project was initially developed in Perl, in 2006, for Linux-users only. You can find more info about it in the related article, clicking on this link: https://www.ncbi.nlm.nih.gov/pmc/articles/PMC1570458
   </p>
   <p>
   Now, we are carrying on this project independently from the original developer and this is the Github page of the NERVE 2.0-stand-alone version. 

--- a/README.md
+++ b/README.md
@@ -154,10 +154,10 @@ But the user can also retrieve a specific proteome from Uniprot, writing its cor
 ```
 Here, the reported Uniprot proteome ID is the one of *Bacillus anthracis* (strain Ames Ancestor).
 
-**The next step is the activation/deactivation of facultative components and their parameters settings.**
+The next step is the activation/deactivation of facultative components and their parameters settings.
 <p>
   
-**Facultative components, deactivated by default, are: Annotation, Loop-Razor, Mouse, NERVirulent and Conservation**.
+Facultative components, deactivated by default, are: Annotation, Loop-Razor, Mouse, NERVirulent and Conservation.
 
 </p>
 See next section for setting examples.
@@ -165,8 +165,22 @@ See next section for setting examples.
 
 ### Showing output and results
 This an output example, showing the percentage of analysis completion:
-
-
+```
+ ./NERVE.sh -p1 test.fasta -g n
+wrote config file /root/.config/epitopepredict/default.conf
+Start NERVE 2.0
+10% done
+20% done
+30% done
+40% done
+50% done
+60% done
+70% done
+80% done
+90% done
+100% done
+End NERVE computation successfully.
+```
 
 The default working directory, where all result files produced during NERVE analysis are saved, is the NERVE folder.
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@
 * **Community-Driven Development:** the open-source model encourages community participation, ensuring that NERVE remains aligned with the evolving needs of the vaccine research community. 
 
 
-Whether it's reporting bugs, suggesting improvements, or developing new features, your input is valuable.
+Whether it's reporting bugs, suggesting improvements, or developing new features, your input is valuable
 
 We welcome contributions from researchers interested in shaping the future of NERVE! 
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 </p>
 <p>
  It further enhances the experience by allowing visualization of analysis results using our 
-  custom-built visualizer. Additionally, this tool facilitates the identification of epitopes (and their constituent parts) predicted to bind to multiple HLA alleles.
+  custom-built visualizer,also facilitating the identification of epitopes (and their constituent parts) predicted to bind to multiple HLA alleles.
   </p>
 </div>
 

--- a/README.md
+++ b/README.md
@@ -59,16 +59,16 @@ We welcome contributions from researchers interested in shaping the future of NE
 ## Installation procedure of stand-alone version:
 NERVE can be used as a stand alone version taking advantage of [Docker](https://www.docker.com/) in Linux systems.
 
-1) Install Docker following [these instructions](https://docs.docker.com/engine/install/) and [the post-installation procedure](https://docs.docker.com/engine/install/linux-postinstall/)
-2) Clone the repository:
+**1) Install Docker following [these instructions](https://docs.docker.com/engine/install/) and [the post-installation procedure](https://docs.docker.com/engine/install/linux-postinstall/):**
+**2) Clone the repository:**
 ```
 git clone https://github.com/nerve-bio/NERVE.git
 ```
-4) Navigate to the correct folder (your default working directory):
+**3) Navigate to the correct folder:**
 ```
 cd NERVE
 ```
-4) Run NERVE (the first time it will take a few minutes)
+**4) Run NERVE (the first time it will take a few minutes)**
 ```
 ./NERVE.sh --help
 ```

--- a/README.md
+++ b/README.md
@@ -1,15 +1,24 @@
 # NERVE
-<div align="center">
+
+<div align="center"
   
   ![nerve](https://github.com/Andrea0097/NERVE/assets/113541183/cebc9a7c-daf5-4ffb-8575-dc5c06df13af)
+
+</div>
   
-  NERVE (New Enhanced Reverse Vaccinology Environment) is an open-source, reverse vaccinology environment, with which you can analyze bacterial proteomes to get the best protein vaccine candidates (PVCs).
+<div align="left" 
+  
+  NERVE (New Enhanced Reverse Vaccinology Environment) is an open-source, reverse vaccinology environment, with which you can analyze bacterial proteomes in FASTA format to get the best protein vaccine candidates (PVCs) and their epitopes. 
   <p>
   The project was initially developed in Perl in 2006. You can find all the related information on the article at: https://www.ncbi.nlm.nih.gov/pmc/articles/PMC1570458
   </p>
   <p>
-  Now, we are carrying on this project independently from the original developer and this is the Github page of the NERVE 2.0-stand-alone version . Web-server app, instead, is available at:
-  https://nerve-bio.org
+  Now, we are carrying on this project independently from the original developer and this is the Github page of the NERVE 2.0-stand-alone version. Users can also leverage a user-friendly web-based 
+  graphical interface (GUI) hosted on our dedicated server: https://nerve-bio.org.
+  </p>
+  <p>
+  This GUI empowers even novice users to operate NERVE with ease, requiring only the proteome FASTA file as input. It further enhances the experience by allowing visualization of analysis results using our 
+  custom-built visualizer. Additionally, this tool facilitates the identification of epitopes (and their constituent parts) predicted to bind to multiple HLA alleles.
   </p>
 </div>
 
@@ -17,12 +26,12 @@
 ### Installation procedure of stand-alone version:
 NERVE can be used as a stand alone verison taking advantage of [Docker](https://www.docker.com/) in Linux systems.
 
-1) install Docker following [these instructions](https://docs.docker.com/engine/install/) and [the post-installation procedure](https://docs.docker.com/engine/install/linux-postinstall/)
-2) clone the repository:
+1) Install Docker following [these instructions](https://docs.docker.com/engine/install/) and [the post-installation procedure](https://docs.docker.com/engine/install/linux-postinstall/)
+2) Clone the repository:
 ```
 git clone https://github.com/nerve-bio/NERVE.git
 ```
-4) navigate to the correct folder:
+4) Navigate to the correct folder:
 ```
 cd NERVE
 ```

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-se # NERVE
+iose # NERVE
 
 <div align="center"
   
@@ -111,7 +111,7 @@ NERVE arguments:
   -m2ovr, --mhcii_overlap 
                         mhcii-epitope overlap (default: 1)
   -prt, --epitope_percentile 
-                        percentile decision threshold on whick to predict epitopes from full length proteins (default: 0.9)
+                        percentile decision threshold on which to predict epitopes from full length proteins (default: 0.9)
   -wd, --working_dir 
                         Path to working directory. If not existing, a working directory with the given path is created (default: ./)
   -nd, --NERVE_dir  Path to NERVE repository folder (download from: https://github.com/nicolagulmini/NERVE) (default: /usr/nerve_python/NERVE)

--- a/README.md
+++ b/README.md
@@ -140,9 +140,9 @@ To start with NERVE, the ```-p1,--proteome1``` file, which contains all bacteria
 ```
 ./NERVE.sh -p1 anthracis.fasta -g p
 ```
-Here, the example file "anthracis.fasta", with Gram positive proteins, needs to be saved in the NERVE folder.
+Here, the example file "anthracis.fasta", with Gram positive proteins, is saved the NERVE folder.
 
-But the user can also retrieve it from Uniprot, writing the correct ID of the chosen proteome:
+But the user can also retrieve a specific proteome from Uniprot, writing its correct ID:
 
 ```
 ./NERVE.sh -p1 UP000000594 -g p

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
   
   NERVE (New Enhanced Reverse Vaccinology Environment) is an open-source, reverse vaccinology environment, with which you can analyze bacterial proteomes in FASTA format to get the best protein vaccine candidates (PVCs) and their epitopes. 
   <p>
-  The project was initially developed in Perl, in 2006, for Linux users only. You can find all the related information on the article at: https://www.ncbi.nlm.nih.gov/pmc/articles/PMC1570458
+  The project was initially developed in Perl, in 2006, for Linux-users only. You can find all the related info on the article at: https://www.ncbi.nlm.nih.gov/pmc/articles/PMC1570458
   </p>
   <p>
   Now, we are carrying on this project independently from the original developer and this is the Github page of the NERVE 2.0-stand-alone version. 

--- a/README.md
+++ b/README.md
@@ -174,8 +174,13 @@ To change it, the user has to specify the path to the new chosen folder using th
 2) The same file with Gram negative proteins will be analyzed activating NERVirulent and setting its cut-off to 0.8 (instead of default " 0.5 "). Without activating Select (```-s False```), PVCs are not filtered. So, in the results file, there will be the list of all proteins with their related analyzed info.
 
 ```
+./NERVE.sh -p1 test.fasta -g n -m True -rz True -rl 75
+```
+3) Here, two facoltative components are activated (Mouse immunity and Loop-razor).Then, minimum length of  considered loop, with Loop-razor, is set to 75aa instead of 50aa.
+
+```
 ./NERVE.sh -p1 test.fasta -g n -p2 test2.fasta
 ```
-3) In this case, adding test2.fasta, the component Conservation is automatically activated, allowing the user to infer antigen conservation.
+4) In this case, adding test2.fasta, the component Conservation is automatically activated, allowing the user to infer antigen conservation.
 
 For more info about components working visit the FAQ section of https://nerve-bio.org

--- a/README.md
+++ b/README.md
@@ -45,7 +45,10 @@
 * **Collaboration:** By enabling researchers to share, modify, and extend the pipeline, leading to innovative advancements. 
 * **Community-Driven Development:** The open-source model encourages community participation, ensuring that NERVE remains aligned with the evolving needs of the vaccine research community. 
 
-We welcome contributions from researchers interested in shaping the future of NERVE! Whether it's reporting bugs, suggesting improvements, or developing new features, your input is valuable.
+
+Whether it's reporting bugs, suggesting improvements, or developing new features, your input is valuable.
+
+We welcome contributions from researchers interested in shaping the future of NERVE! 
 
 
 ## Installation procedure of stand-alone version:

--- a/README.md
+++ b/README.md
@@ -150,13 +150,16 @@ But the user can also retrieve a specific proteome from Uniprot, writing its cor
 Here, the reported Uniprot proteome ID is the one of *Bacillus anthracis* (strain Ames Ancestor).
 
 The next step is the activation/deactivation of facultative components and their parameters settings.
-Facultative components, deactivated by default, are: Annotation, Loop-Razor, Mouse, NERVirulent and Conservation 
+Facultative components, deactivated by default, are: Annotation, Loop-Razor, Mouse, NERVirulent and Conservation.
+See next section to see some setting examples.
 
 
 ### Showing output and results
-This an output example, showing the percentage of 
+This an output example, showing the percentage of analysis completion:
 
-The default working directory, where all result files produced during NERVE analysis are saved, is always the NERVE folder.
+
+
+The default working directory, where all result files produced during NERVE analysis are saved, is the NERVE folder.
 
 To change it, use ``-wd,--working_dir``` as showed:
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# NERVE
+ # NERVE
 
 <div align="center"
   
@@ -22,8 +22,30 @@
   </p>
 </div>
 
+## Key features:
 
-### Installation procedure of stand-alone version:
+ * **Machine Learning and Alignment Analysis**, using  ML methods for antigen analysis
+ * **Flexible Usage**, customizing your settings
+ * **Stand-alone Docker Version**, working across Windows, macOS, and Linux.
+ * **Intuitive Web-based GUI**,
+ * **Complete Python Rewrite**, enhancing its performance and maintainability.
+ * **Ongoing Development**, continuously evolving with new features and improvements.
+ * **Comprehensive Output**, including:
+    * A CSV file summarizing all candidate proteins with scores and predicted characteristics (P_adhesin, P_antigen, location, etc.).
+    * A separate CSV file listing discarded proteins.
+    * Dedicated folders containing additional files (CSVs and PNGs) for each selected protein with predicted linear epitopes. 
+
+**Benefits for Vaccine Research:**
+
+* **Accessibility:**: Researchers worldwide can access and utilize NERVE without barriers, accelerating vaccine development efforts globally. 
+* **Transparency:** Allowing researchers to scrutinize the code, identify potential issues, and contribute to its refinement. 
+* **Collaboration:** By enabling researchers to share, modify, and extend the pipeline, leading to innovative advancements. 
+* **Community-Driven Development:** The open-source model encourages community participation, ensuring that NERVE remains aligned with the evolving needs of the vaccine research community. 
+
+We welcome contributions from researchers interested in shaping the future of NERVE! Whether it's reporting bugs, suggesting improvements, or developing new features, your input is valuable.
+
+
+## Installation procedure of stand-alone version:
 NERVE can be used as a stand alone verison taking advantage of [Docker](https://www.docker.com/) in Linux systems.
 
 1) Install Docker following [these instructions](https://docs.docker.com/engine/install/) and [the post-installation procedure](https://docs.docker.com/engine/install/linux-postinstall/)
@@ -94,7 +116,7 @@ NERVE arguments:
   -epp, --ep_plots  Epitopes plotting script (default: True)
   ```
 
-### Common usage and tips:
+## Common usage and tips:
 
 With help, you can visualize all possible arguments, which include all user-settable parameters and activation or deactivation of NERVE components.
 Definitions and setting options are shown in detail for each of them.

--- a/README.md
+++ b/README.md
@@ -8,12 +8,12 @@
   
 <div align="left" 
   
-  NERVE (New Enhanced Reverse Vaccinology Environment) is an open-source, reverse vaccinology environment, with which you can analyze bacterial proteomes in FASTA format to get the best protein vaccine candidates (PVCs) and their epitopes. 
+  **NERVE** (**New Enhanced Reverse Vaccinology Environment**) is an **open-source**, **reverse vaccinology** environment, with which you can analyze bacterial proteomes in FASTA format to get the best protein vaccine candidates (PVCs) and their epitopes. 
   <p>
   The project was initially developed in Perl, in 2006, for Linux-users only. You can find more info about it in the related article, clicking on this link: https://www.ncbi.nlm.nih.gov/pmc/articles/PMC1570458
   </p>
   <p>
-  Now, we are carrying on this project independently from the original developer and this is the Github page of the NERVE 2.0-stand-alone version. 
+  Now, we are carrying on this project independently from the original developer and this is the Github page of the **NERVE 2.0-stand-alone version**. 
   </p>
   <p>
   Users can also leverage a user-friendly web-based 

--- a/README.md
+++ b/README.md
@@ -8,20 +8,25 @@
   
 <div align="left" 
   
-  **NERVE** (**New Enhanced Reverse Vaccinology Environment**) is an **open-source**, **reverse vaccinology** environment, with which you can analyze bacterial proteomes in FASTA format to get the best protein vaccine candidates (PVCs) and their epitopes. 
+  **NERVE** (**New Enhanced Reverse Vaccinology Environment**) is an **open-source**, **reverse vaccinology** environment, with which you can analyze bacterial proteomes in **FASTA format** to get the best **protein vaccine candidates (PVCs)** and their epitopes. 
   <p>
   The project was initially developed in Perl, in 2006, for Linux-users only. You can find more info about it in the related article, clicking on this link: https://www.ncbi.nlm.nih.gov/pmc/articles/PMC1570458
   </p>
   <p>
+    
   Now, we are carrying on this project independently from the original developer and this is the Github page of the **NERVE 2.0-stand-alone version**. 
+  
   </p>
   <p>
-  Users can also leverage a user-friendly web-based 
-  graphical interface (GUI) hosted on our dedicated server: https://nerve-bio.org.  This GUI empowers even novice users to operate NERVE with ease, requiring only the proteome FASTA file as input.
+    
+  Users can also leverage a **user-friendly web-based graphical interface (GUI)** hosted on our dedicated server: **https://nerve-bio.org**.  This GUI empowers even novice users to operate NERVE with ease, requiring only the proteome FASTA file as input.
+  
 </p>
 <p>
+  
  It further enhances the experience by allowing visualization of analysis results using our 
-  custom-built visualizer, also facilitating the identification of epitopes (and their constituent parts) predicted to bind to multiple HLA alleles.
+  custom-built visualizer, also facilitating the **identification of epitopes** (and their constituent parts) predicted to bind to multiple HLA alleles.
+  
   </p>
 </div>
 

--- a/README.md
+++ b/README.md
@@ -53,13 +53,13 @@
 
 Whether it's reporting bugs, suggesting improvements, or developing new features, your input is valuable.
 
-We welcome contributions from researchers interested in shaping the future of NERVE! 
+**We welcome contributions from researchers interested in shaping the future of NERVE!** 
 
 
 ## Installation procedure of stand-alone version:
 NERVE can be used as a stand alone version taking advantage of [Docker](https://www.docker.com/) in Linux systems.
 
-**1) Install Docker following [these instructions](https://docs.docker.com/engine/install/) and [the post-installation procedure](https://docs.docker.com/engine/install/linux-postinstall/):**
+**1) Install Docker following [these instructions](https://docs.docker.com/engine/install/) and [the post-installation procedure](https://docs.docker.com/engine/install/linux-postinstall/).**
 
 **2) Clone the repository:**
 ```
@@ -106,7 +106,7 @@ NERVE arguments:
                         Parameter of select module. Proteins with trasmembrane domains >= transmemb_doms_limit are discarded (default: 3)
   -vl, --virlimit   Cut-off value for NERVirulent in the select module (0.-1) (default: 0.5)
   -vir, --virulent  Activation (True) or deactivation (False) of NERVirulent module, predictor of the probability of being a virulence factor (default: False)
-  -ep, --epitopes   Activate or deactivate epitopes module (default: True)
+  -ep, --epitopes   Activate or deactivate epitope prediction module (default: True)
   -m1l, --mhci_length 
                         mhci binders length (9, 10, 11 are available) (default: 9)
   -m2l, --mhcii_length 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,18 @@
 # NERVE
+<div align="center">
+  
+  ![nerve](https://github.com/Andrea0097/NERVE/assets/113541183/cebc9a7c-daf5-4ffb-8575-dc5c06df13af)
+  
+  NERVE (New Enhanced Reverse Vaccinology Environment) is an open-source, reverse vaccinology environment, with which you can analyze bacterial proteomes to get the best protein vaccine candidates (PVCs).
+  <p>
+  The project was initially developed in Perl in 2006. You can find all the related information on the article at: https://www.ncbi.nlm.nih.gov/pmc/articles/PMC1570458
+  </p>
+  <p>
+  Now, we are carrying on this project independently from the original developer and this is the Github page of the NERVE 2.0-stand-alone version . Web-server app, instead, is available at:
+  https://nerve-bio.org
+  </p>
+</div>
 
-NERVE (New Enhanced Reverse Vaccinology Environment) is an open-source, reverse vaccinology environment, with which you can analyze bacterial proteomes to get the best protein vaccine candidates (PVCs).
-<p>
-The project was initially developed in Perl in 2006. You can find all the related information on the article at: https://www.ncbi.nlm.nih.gov/pmc/articles/PMC1570458
-</p>
-<p>
-Now we are carrying on this project independently from the original developer and this is the Github page of the stand-alone version of NERVE 2.0. Web-server app, instead, is available at:
-https://nerve-bio.org
-</p>
 
 ### Installation procedure of stand-alone version:
 NERVE can be used as a stand alone verison taking advantage of [Docker](https://www.docker.com/) in Linux systems.
@@ -26,13 +31,13 @@ cd NERVE
 ./NERVE.sh --help
 
 ```
-With help, you can visualize all arguments (parameters and modules of NERVE).
-Expected output:
+
+This is the expected output:
 ```
 usage: NERVE.py [-h] [-a] [-ev] -g [-ml] [-mm] [-m] [-mpsl] -p1 [-p2] [-pl] [-rz] [-rl] [-s] [-ss] [-tdl] [-vl] [-vir]
                 [-ep] [-m1l] [-m2l] [-m1ovr] [-m2ovr] [-prt] [-wd] [-nd] [-id] [-dfd] [-epp]
 
-optional arguments:
+NERVE arguments:
   -h, --help        show this help message and exit
   -a, --annotation  Activation (True) or deactivation (False) of annotation module. Uses DeepFri to retrieve protein functional onthologies (default: True)
   -ev, --e_value    Expect-value used in blastp for immunity modules (default: 1e-10)
@@ -80,5 +85,32 @@ optional arguments:
   -epp, --ep_plots  Epitopes plotting script (default: True)
   ```
 
-### Common usage:
+### Common usage and tips:
+
+With help, you can visualize all possible arguments, which include all user-settable parameters and activation or deactivation of NERVE components.
+Definitions and setting options are shown in detail for each of them.
+
+**Mandatory arguments:** 
+* ```-p1  ```,```--proteome1  ``` 
+* ```-g ```,  ```--gram ``` 
+
+All the other arguments, showed in the help section are optional. So, if they're set by the user, their related default value is used during NERVE computation.
+
+**Here is a list of different examples to show how to correctly set NERVE arguments:**
+
+```
+./NERVE.sh -p1 test.fasta -g n
+```
+1) This is a run example with the minimum number of arguments (the two mandatory ones). Here we're considering a file with Gram negative proteins.
+
+```
+./NERVE.sh -p1 test.fasta -g n -s False -vir True -vl 0.8
+```
+2) The same file with gram negative proteins will be analyzed activating NERVirulent and setting its cut-off to 0.8 (instead of default " 0.5 "). Without activating Select (```-s False```), PVCs are not filtered so in the results file there will be the list of all proteins with their related analyzed info.
+
+```
+./NERVE.sh -p1 test.fasta -g n -p2 test2.fasta
+```
+3) In this case, adding test2.fasta, the component Conservation is automatically activated, allowing the user to infer antigen conservation. 
+For more info about components working visit the FAQ section of https://nerve-bio.org
 

--- a/README.md
+++ b/README.md
@@ -158,7 +158,8 @@ Here, the reported Uniprot proteome ID is the one of *Bacillus anthracis* (strai
 The next step is the activation/deactivation of facultative components and their parameters settings.
 <p>
   
-Facultative components, deactivated by default, are: Annotation, Loop-Razor, Mouse, NERVirulent and Conservation.
+Facultative components are: Annotation, Loop-Razor, Mouse immunity, NERVirulent, Conservation, Select and Epitope prediction.
+Only the last two ones are acttivated by default.
 
 </p>
 See last section for setting examples.


### PR DESCRIPTION
I updated READ ME file adding more info and tips for installation

Help output has to be the same of the --help showed in the updated README.
This one differently from the other has these corrections:
1) no pae and pac filter (we removed them)
2) corrections of some words or terms
3) correction of padlimit to 0.5 as default 

(the program has already implemented 1 and 3, only the help descriptions have to be corrected)
